### PR TITLE
add ability to specify loadBalancerIP and loadBalancerSourceRanges on Service configuration

### DIFF
--- a/charts/traccar/templates/ingress.yaml
+++ b/charts/traccar/templates/ingress.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "traccar.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "traccar.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
+  {{- with .Values.ingress.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: ImplementationSpecific
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/traccar/templates/service.yaml
+++ b/charts/traccar/templates/service.yaml
@@ -1,22 +1,40 @@
+{{- $fullName := include "traccar.fullname" . -}}
+{{- $externalfullname := printf "external-%s" $fullName -}}
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "traccar.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "traccar.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
-{{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-{{- end }}
-{{- if .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
-{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
-    {{- toYaml .Values.service.protocolPorts | nindent 4 }}
   selector:
     {{- include "traccar.selectorLabels" . | nindent 4 }}
+---
+{{- if .Values.externalService.enabled -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $externalfullname }}
+  labels:
+    {{- include "traccar.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.externalService.type }}
+{{- if .Values.externalService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.externalService.loadBalancerIP }}
+{{- end }}
+{{- if .Values.externalService.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.externalService.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+  ports:
+    {{- toYaml .Values.externalService.protocolPorts | nindent 4 }}
+  selector:
+    {{- include "traccar.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/traccar/templates/service.yaml
+++ b/charts/traccar/templates/service.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "traccar.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -131,11 +131,31 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+ingress:
+  enabled: false
+  extraAnnotations: {}
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: traccar.example.com
+      paths:
+        - /
+  tls: []
+  # - secretName: traccar-tls
+  #   hosts:
+  #     - traccar.example.com
+
 service:
   type: ClusterIP
+  port: 80
+
+externalService:
+  type: LoadBalancer
+  enabled: false
   # loadBalancerIP: ""
   # loadBalancerSourceRanges: []
-  port: 80
   protocolPorts:
   - name: gps103
     port: 5001

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -133,6 +133,8 @@ securityContext:
 
 service:
   type: ClusterIP
+  # loadBalancerIP: ""
+  # loadBalancerSourceRanges: []
   port: 80
   protocolPorts:
   - name: gps103


### PR DESCRIPTION
Hi,

I would like to add loadBalancerIP, and loadBalancerSourceRanges in your helm chart.

I hope that it will be accepted :) 

Signed-off-by: Romain Labat <contact@romainlabat.fr>