### PR TITLE
security context to init container

### DIFF
--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
 {{- if .Values.mysql.enabled }}
       initContainers:
         - name: wait-for-db
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "alpine:3.6"
           command:
             - 'sh'


### PR DESCRIPTION
Add security context to init container so that it works on RKE2 which has a restricted cluster wide psp blocking root user.