### PR TITLE
Always add checksum/config

### DIFF
--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "4.13"
 dependencies:
   - name: mysql

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -13,11 +13,9 @@ spec:
     type: Recreate
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-      {{- end }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels:
         {{- include "traccar.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -15,7 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "traccar.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
Currently the checksum is only added when you add your own podAnnotations. This prevents the pod to be recreated on config changes.
With this change the checksum/config is always added and the pod will be recreated on a config change.