### PR TITLE
add image.flavor to allow choosing between alpine, debian and ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ The command removes all the Kubernetes components associated with the deplyoment
 
 ### Parameters
 The chart incorporates every configuration file setting, which can be found [ here](https://www.traccar.org/configuration-file/)
+
+### Image flavors
+The [traccar container image](https://github.com/traccar/traccar-docker) comes in _different flavors_. Currently available are
+* alpine
+* debian
+* ubuntu
+If none is specified during installation of this chart, the default is alpine based.
+
+To set your preferred flavor, you can use `--set image.flavor=debian` for example, or, for more reusability, append the following lines to your installation's `values.yaml`
+```yaml
+image:
+  flavor: "debian"
+```

--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: "5.6"
 dependencies:
   - name: mysql

--- a/charts/traccar/templates/_helpers.tpl
+++ b/charts/traccar/templates/_helpers.tpl
@@ -60,3 +60,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "traccar.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- if .Values.image.flavor }}
+{{- printf "%s:%s-%s" .Values.image.repository $tag .Values.image.flavor }}
+{{- else }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+{{- end }}

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "traccar.image" . }}
           command: ["java", "-Xms512m", "-Xmx512m", "-Djava.net.preferIPv4Stack=true"]
           args: ["-jar", "tracker-server.jar", "conf/traccar.xml"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -118,6 +118,7 @@ mysql:
 image:
   repository: traccar/traccar
   pullPolicy: IfNotPresent
+  # flavor: "" # available are alpine, debian or ubuntu
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 


### PR DESCRIPTION
As https://github.com/traccar/traccar-docker and https://hub.docker.com/r/traccar/traccar show 3 different image flavors (`alpine`, `debian` and `ubuntu`), it would be nice to be able to configure just the flavor, without having to worry about manually updating the full tag, when there's a new traccar release.

Default value
```
$ helm template .  | grep 'image: traccar'
          image: traccar/traccar:4.13
```

Custom tag
```
$ helm template . --set image.tag=v1234 | grep 'image: traccar'
          image: traccar/traccar:v1234
```

(so no breaking of existing behaviour)

Setting the flavor
```
$ helm template . --set image.flavor=alpine | grep 'image: traccar'
          image: traccar/traccar:4.13-alpine
```

Setting the flavor and a custom version through `image.tag`
```
$ helm template . --set image.flavor=alpine,image.tag=v123 | grep 'image: traccar'
          image: traccar/traccar:v123-alpine
```