### PR TITLE
add support for custom initContainers

### DIFF
--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -32,8 +32,9 @@ spec:
         - name: config
           configMap:
             name: {{ include "traccar.fullname" . }}
-{{- if .Values.mysql.enabled }}
+{{- if or .Values.mysql.enabled .Values.initContainers }}
       initContainers:
+{{- if .Values.mysql.enabled }}
         - name: wait-for-db
           image: "alpine:3.6"
           command:
@@ -43,6 +44,14 @@ spec:
               until nc -z -w 2 {{ include "traccar.fullname" . }}-mysql 3306 && echo mysql ok;
                 do sleep 2;
               done
+{{- end }}
+{{- with .Values.initContainers }}
+        {{- if eq (typeOf .) "string" }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -147,6 +147,9 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+# A list of initContainers to run before the pod starts
+initContainers: []
+
 ingress:
   enabled: false
   extraAnnotations: {}


### PR DESCRIPTION
My usecase for it is, for example, as I use an externally (as in, to the chart) provided database cluster, the hardcoded `wait-for-db` `initContainer` just doesn't do it. And users might want to add additional containers or checks.

So, in my case, passing
```yaml
initContainers: |
  - name: wait-for-db
    image: ghcr.io/tamcore/alpine-psql:3.17.1
    command: ["/bin/sh"]
    args:
    - "-c"
    - "until pg_isready -h ${POSTGRES_HOST} -U ${POSTGRES_USER} ; do sleep 2 ; done"
    securityContext:
      {{- toYaml .Values.securityContext | nindent 4 }}
    env:
      - name: POSTGRES_USER
        valueFrom:
          secretKeyRef:
            name: traccar.traccar-postgresql.credentials.postgresql.acid.zalan.do
            key: username
      - name: POSTGRES_PASSWORD
        valueFrom:
          secretKeyRef:
            name: traccar.traccar-postgresql.credentials.postgresql.acid.zalan.do
            key: password
      - name: POSTGRES_DATABASE
        value: "{{ (split "/" .Values.traccar.database.url)._3 }}"
      - name: POSTGRES_HOST
        value: "{{ (split "/" .Values.traccar.database.url)._2 }}"
mysql:
  enabled: false
```
to the chart, results in a created Deployment with
```yaml
spec:
  template:
    spec:
      initContainers:
        - name: wait-for-db
          image: ghcr.io/tamcore/alpine-psql:3.17.1
          command: ["/bin/sh"]
          args:
          - "-c"
          - "until pg_isready -h ${POSTGRES_HOST} -U ${POSTGRES_USER} ; do sleep 2 ; done"
          securityContext:
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: false
            runAsNonRoot: true
            runAsUser: 1000
          env:
            - name: POSTGRES_USER
              valueFrom:
                secretKeyRef:
                  name: traccar.traccar-postgresql.credentials.postgresql.acid.zalan.do
                  key: username
            - name: POSTGRES_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: traccar.traccar-postgresql.credentials.postgresql.acid.zalan.do
                  key: password
            - name: POSTGRES_DATABASE
              value: "traccar"
            - name: POSTGRES_HOST
              value: "traccar-postgresql"
      containers:
        - name: traccar
...snip....
```