### PR TITLE
make command, args and env configurable

### DIFF
--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: "5.6"
 dependencies:
   - name: mysql

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -60,8 +60,18 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "traccar.image" . }}
-          command: ["java", "-Xms512m", "-Xmx512m", "-Djava.net.preferIPv4Stack=true"]
-          args: ["-jar", "tracker-server.jar", "conf/traccar.xml"]
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -151,6 +151,25 @@ securityContext:
 # A list of initContainers to run before the pod starts
 initContainers: []
 
+command: ["java", "-Xms512m", "-Xmx512m", "-Djava.net.preferIPv4Stack=true"]
+args: ["-jar", "tracker-server.jar", "conf/traccar.xml"]
+
+# This allows you to use environment variables (i.e. referenced from Secrets) to use in your configuration
+# The names of the keys are identical. But, a dot (.), you'll have to use an underscore (_) and define everything in UPPERCASE
+env: []
+# - name: "CONFIG_USE_ENVIRONMENT_VARIABLES"
+#   value: "true"
+# - name: "DATABASE_USER"
+#   valueFrom:
+#     secretKeyRef:
+#       name: "postgres-secrets"
+#       key: "username"
+# - name: "DATABASE_PASSWORD"
+#   valueFrom:
+#     secretKeyRef:
+#       name: "postgres-secrets"
+#       key: "password"
+
 ingress:
   enabled: false
   extraAnnotations: {}


### PR DESCRIPTION
Because of the version bump, this will conflict with PR #20. Depending on which one gets merged first, i'll quickly fix the other one :)

This change makes the `command` and `args`, which were hardcoded, configurable. So a user, for example, can change the `Xms` and `Xmx` parameters to his liking, or do other whichcraft. 

Additionally, I've introduced `env`, which will allow it to use environment variables for configuration. That'll make it much easier for cases where the database credentials are externally provided as Secrets. Like with my case, where the Secret is created by the postgres-operator, or cases where a user might choose to use ExternalSecrets for example. (See the example in the `values.yaml`) Additionally, as the config is stored as a ConfigMap and not a Secret, that's not where one should store passwords :)