### PR TITLE
bump appVersion to 5.10, allow multiple replicas (+HPA) for Deployment, allow setting externalService annotations, allow disabling allocateLoadBalancerNodePorts, add redis-ha subchart+config

### DIFF
--- a/charts/traccar/Chart.lock
+++ b/charts/traccar/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 9.4.8
-digest: sha256:c54ca45ec9055b33d96c582be62d5c4afd9501f2edfee0afaa73876b7ae13cfa
-generated: "2023-01-28T11:57:35.495179799+01:00"
+- name: redis-ha
+  repository: https://dandydeveloper.github.io/charts
+  version: 4.23.0
+digest: sha256:91b7dd321c826a5721204763f11ac8a641c60cc23690250ca2eecd8c368cdac8
+generated: "2023-12-09T13:20:23.900368+01:00"

--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,13 +2,17 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.6.0
-appVersion: "5.6"
+version: 1.7.0
+appVersion: "5.10"
 dependencies:
   - name: mysql
     version: 9.4.8
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
+  - name: redis-ha
+    version: 4.23.0
+    repository: https://dandydeveloper.github.io/charts
+    condition: redis-ha.enabled
 maintainers:
   - email: laszlo.kondas@gmail.com
     name: kondas

--- a/charts/traccar/ci/ha-with-redis-values.yaml
+++ b/charts/traccar/ci/ha-with-redis-values.yaml
@@ -1,0 +1,14 @@
+replicaCount: 2
+
+deploymentStrategy:
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+  type: RollingUpdate
+
+redis-ha:
+  enabled: true
+  # defaults to 3. but we wan't CI to run through in a reasonable time.
+  replicas: 1
+  haproxy:
+    replicas: 1

--- a/charts/traccar/templates/configmap.yaml
+++ b/charts/traccar/templates/configmap.yaml
@@ -402,5 +402,9 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if (index .Values "redis-ha").enabled }}
+        <entry key='broadcast.type'>redis</entry>
+        <entry key='broadcast.address'>redis://{{ include "traccar.fullname" . }}-redis-ha-haproxy:6379</entry>
+{{- end }}
     </properties>
 {{- end }}

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -5,12 +5,16 @@ metadata:
   labels:
     {{- include "traccar.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "traccar.selectorLabels" . | nindent 6 }}
+  {{- with .Values.deploymentStrategy }}
   strategy:
-    type: Recreate
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -32,18 +36,31 @@ spec:
         - name: config
           configMap:
             name: {{ include "traccar.fullname" . }}
-{{- if or .Values.mysql.enabled .Values.initContainers }}
+{{- if or .Values.mysql.enabled (index .Values "redis-ha").enabled .Values.initContainers }}
       initContainers:
 {{- if .Values.mysql.enabled }}
         - name: wait-for-db
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "alpine:3.6"
+          image: "alpine:3.19"
           command:
             - 'sh'
             - '-c'
             - >
               until nc -z -w 2 {{ include "traccar.fullname" . }}-mysql 3306 && echo mysql ok;
+                do sleep 2;
+              done
+{{- end }}
+{{- if (index .Values "redis-ha").enabled }}
+        - name: wait-for-redis
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "alpine:3.19"
+          command:
+            - 'sh'
+            - '-c'
+            - >
+              until nc -z -w 2 {{ include "traccar.fullname" . }}-redis-ha-haproxy 6379 && echo redis ok;
                 do sleep 2;
               done
 {{- end }}

--- a/charts/traccar/templates/hpa.yaml
+++ b/charts/traccar/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "traccar.fullname" . }}
+  labels:
+    {{- include "traccar.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "traccar.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/traccar/templates/service.yaml
+++ b/charts/traccar/templates/service.yaml
@@ -25,6 +25,10 @@ metadata:
   name: {{ $externalfullname }}
   labels:
     {{- include "traccar.labels" . | nindent 4 }}
+  {{- with .Values.externalService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.externalService.type }}
 {{- if .Values.externalService.loadBalancerIP }}
@@ -32,6 +36,9 @@ spec:
 {{- end }}
 {{- if .Values.externalService.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.externalService.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+{{- if hasKey .Values.externalService "allocateLoadBalancerNodePorts" }}
+  allocateLoadBalancerNodePorts: {{ .Values.externalService.allocateLoadBalancerNodePorts }}
 {{- end }}
   ports:
     {{- toYaml .Values.externalService.protocolPorts | nindent 4 }}

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -115,6 +115,19 @@ mysql:
     persistence:
       enabled: false
 
+# NOTE: When using multiple replicas, you must configure broadcast.type and broadcast.address
+#       This can be done via configOverride. See https://www.traccar.org/configuration-file/#:~:text=attributes%20to%20log.-,broadcast.type,-config
+#       Or by setting redis.enabled=true
+replicaCount: 1
+
+deploymentStrategy:
+  # Recreate has been the default until chart version 1.6.0 and is required if running a non-HA compatible setup
+  type: Recreate
+  # rollingUpdate:
+  #   maxSurge: 25%
+  #   maxUnavailable: 25%
+  # type: RollingUpdate
+
 image:
   repository: traccar/traccar
   pullPolicy: IfNotPresent
@@ -193,8 +206,15 @@ service:
 externalService:
   type: LoadBalancer
   enabled: false
+  annotations: {}
+    # metallb.universe.tf/loadBalancerIPs: 192.168.1.100
   # loadBalancerIP: ""
   # loadBalancerSourceRanges: []
+
+  # -- Enable node port allocation for the external controller service or not. Applies to type `LoadBalancer` only.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
+  # allocateLoadBalancerNodePorts: true
+
   protocolPorts:
   - name: gps103
     port: 5001
@@ -876,8 +896,27 @@ externalService:
 
 resources: {}
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 nodeSelector:
 
 tolerations: []
 
 affinity: {}
+
+redis-ha:
+  # enables the redis subchart
+  enabled: false
+  persistentVolume:
+    enabled: false
+  redis:
+    masterGroupName: traccar
+  config:
+    save: '""'
+  haproxy:
+    enabled: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,4 +5,5 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
+  - dandydeveloper=https://dandydeveloper.github.io/charts
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
Sorry for the big PR. Didn't want to create 10 individual ones for such small things :) 

- bump chart version to 1.7.0
- bump app version from 5.6 to 5.10 (this bit should probably be automated)
- externalService: allow configuring annotations (as spec.loadBalancerIP is deprecated: https://github.com/kubernetes/kubernetes/pull/107235)
- externalService: allow disabling of `allocateLoadBalancerNodePorts` which is not required with LoadBalancer implementations like MetalLB
- deployment: allow multiple replicas, as since v5.10 traccar supports redis
- deployment: allow configuring a custom deployment strategy, as Recreate is no longer needed, if the setup is configured for HA
- add a manifest for HPA, because why not
- add basic configuration to enable redis-ha (setting `redis-ha.enabled` deploys Redis and configures traccar to use it)