### PR TITLE
fix: add dandydeveloper repo to release workflow and bump chart for re-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Add Helm dependency repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts
           helm repo update
 
       - name: Run chart-releaser

--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: "5.10"
 dependencies:
   - name: mysql


### PR DESCRIPTION
Fixes the
```
Error: no repository definition for https://dandydeveloper.github.io/charts
```
error in the release workflow by adding the repo to it re-releases the chart by bumping the version.

Sorry for the inconvenience.