### PR TITLE
fix env var rendering with secretKeyFrom

### DIFF
--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -91,9 +91,25 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.env }}
           env:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.env }}
+          {{- if kindIs "map" .Values.env }}
+          {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- else if kindIs "slice" .Values.env }}
+          {{- range .Values.env }}
+            - name: {{ .name | quote }}
+              {{- if .value }}
+              value: {{ .value | quote }}
+              {{- end }}
+              {{- if .valueFrom }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- if not .Values.configOverride }}
           envFrom:


### PR DESCRIPTION
I couldn't get the Deployment to render, no matter which combination of formats I tried. The [values.yaml example ](https://github.com/traccar/traccar-helm/blob/main/charts/traccar/values.yaml#L175-L186) didn't work, as well.

With this change I'm able to use this, which seems to be what the example suggest should work. The secret-binding also works:
```
env:
  - name: CONFIG_USE_ENVIRONMENT_VARIABLES
    value: "true"
  - name: DATABASE_DRIVER
    value: "org.postgresql.Driver"
  - name: DATABASE_URL
    value: "jdbc:postgresql://traccar-db-postgrespg:5432/postgres"
  - name: DATABASE_USER
    valueFrom:
      secretKeyRef:
        name: traccar-db-env
        key: DB_USERNAME
  - name: DATABASE_PASSWORD
    valueFrom:
      secretKeyRef:
        name: traccar-db-env
        key: DB_PASSWORD
```

This notation also works, although there is some warning:
```  
env:
  CONFIG_USE_ENVIRONMENT_VARIABLES: true
  DATABASE_DRIVER: "org.postgresql.Driver"
  DATABASE_URL: "jdbc:postgresql://traccar-db-postgrespg:5432/traccar-db"
```