### PR TITLE
Update Traccar to 6.14 and add webOverride volume configuration

### DIFF
--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.9.1
-appVersion: "5.10"
+version: 1.10.0
+appVersion: "6.14"
 dependencies:
   - name: mysql
     version: 9.4.8

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
         - name: config
           configMap:
             name: {{ include "traccar.fullname" . }}
+        - name: web-override
+          {{- toYaml .Values.webOverride | nindent 10 }}
 {{- if or .Values.mysql.enabled (index .Values "redis-ha").enabled .Values.initContainers }}
       initContainers:
 {{- if .Values.mysql.enabled }}
@@ -781,6 +783,8 @@ spec:
           - name: "config"
             subPath: "traccar.xml"
             mountPath: "/opt/traccar/conf/traccar.xml"
+          - name: "web-override"
+            mountPath: "/opt/traccar/override"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -942,3 +942,6 @@ readinessProbe:
   periodSeconds: 60
   failureThreshold: 1
   timeoutSeconds: 1
+
+webOverride:
+  emptyDir: {}

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -168,7 +168,7 @@ securityContext:
 # A list of initContainers to run before the pod starts
 initContainers: []
 
-command: ["java", "-Xms512m", "-Xmx512m", "-Djava.net.preferIPv4Stack=true"]
+command: ["/opt/traccar/jre/bin/java", "-Xms512m", "-Xmx768m", "-Djava.net.preferIPv4Stack=true"]
 args: ["-jar", "tracker-server.jar", "conf/traccar.xml"]
 
 # This allows you to use environment variables (i.e. referenced from Secrets) to use in your configuration

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -168,7 +168,7 @@ securityContext:
 # A list of initContainers to run before the pod starts
 initContainers: []
 
-command: ["/opt/traccar/jre/bin/java", "-Xms512m", "-Xmx768m", "-Djava.net.preferIPv4Stack=true"]
+command: ["/opt/traccar/jre/bin/java", "-Xms512m", "-Xmx512m", "-Djava.net.preferIPv4Stack=true"]
 args: ["-jar", "tracker-server.jar", "conf/traccar.xml"]
 
 # This allows you to use environment variables (i.e. referenced from Secrets) to use in your configuration


### PR DESCRIPTION
Updates helm chart to deploy latest traccar tag (https://www.traccar.org/blog/traccar-6-14/)

It mostly works out of the box, but there is one minor issue with file permissions due to the new `web.override` feature.

## Problem

```
2026-06-10 04:24:10 ERROR: Main method error - /opt/traccar/./override - AccessDeniedException
```

From https://www.traccar.org/configuration-file/

> web.override config
> Path to a folder with overrides. It can be used for branding to keep custom logos in a separate place.
> Default value: "./override"

## Solution

To fix this, we add support for custom UI override volumes by exposing a `webOverride` key in `values.yaml` and mapping it to `/opt/traccar/override`. By default, we make it an `emptyDir`. Users can specify a configmap if needed, e.g.:

```
    webOverride:
      configMap:
        name: my-traccar-branding-assets
```

## Testing Done

Deployed to my own k8s cluster. Verified pod comes up healthy and tracking works.

Fixes https://github.com/traccar/traccar-helm/issues/43
