### PR TITLE
Fix: Use legacy Bitnami registry for MySQL dependency to resolve CI failure

### DIFF
--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.9.0
+version: 1.9.1
 appVersion: "5.10"
 dependencies:
   - name: mysql

--- a/charts/traccar/ci/default-values.yaml
+++ b/charts/traccar/ci/default-values.yaml
@@ -104,6 +104,8 @@ traccar:
 
 mysql:
   enabled: true
+  image:
+    repository: bitnamilegacy/mysql
   auth:
     database: "traccar"
     username: "traccar"

--- a/charts/traccar/ci/test-values.yaml
+++ b/charts/traccar/ci/test-values.yaml
@@ -104,6 +104,8 @@ traccar:
 
 mysql:
   enabled: true
+  image:
+    repository: bitnamilegacy/mysql
   auth:
     database: "traccar"
     username: "traccar"

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -104,6 +104,8 @@ traccar:
 
 mysql:
   enabled: true
+  image:
+    repository: bitnamilegacy/mysql
   auth:
     database: "traccar"
     username: "traccar"


### PR DESCRIPTION
Fixes #42.

This PR updates the default MySQL image repository to `bitnamilegacy/mysql` to resolve the `ImagePullBackOff` failure in CI caused by Bitnami's repository restructuring (which moved version-pinned tags to a legacy namespace).

This maintains compatibility for existing users without forcing a major version upgrade of MySQL.