### PR TITLE
Feat: Add configurable media volume support

### DIFF
--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traccar
 description: A Helm chart for Traccar GPS Server
 type: application
-version: 1.10.0
+version: 1.10.1
 appVersion: "6.14"
 dependencies:
   - name: mysql

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -36,14 +36,24 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "traccar.serviceAccountName" . }}
+      {{- $podSec := .Values.podSecurityContext }}
+      {{- if and .Values.media.enabled (not .Values.podSecurityContext.fsGroup) .Values.securityContext.runAsUser }}
+        {{- $podSec = merge (dict "fsGroup" .Values.securityContext.runAsUser) .Values.podSecurityContext }}
+      {{- end }}
+      {{- if not (empty $podSec) }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml $podSec | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "traccar.fullname" . }}
         - name: web-override
           {{- toYaml .Values.webOverride | nindent 10 }}
+        {{- if .Values.media.enabled }}
+        - name: media
+          {{- toYaml (omit .Values.media "enabled") | nindent 10 }}
+        {{- end }}
 {{- if or .Values.mysql.enabled (index .Values "redis-ha").enabled .Values.initContainers }}
       initContainers:
 {{- if .Values.mysql.enabled }}
@@ -785,6 +795,10 @@ spec:
             mountPath: "/opt/traccar/conf/traccar.xml"
           - name: "web-override"
             mountPath: "/opt/traccar/override"
+          {{- if .Values.media.enabled }}
+          - name: "media"
+            mountPath: "/opt/traccar/media"
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/traccar/values.yaml
+++ b/charts/traccar/values.yaml
@@ -945,3 +945,15 @@ readinessProbe:
 
 webOverride:
   emptyDir: {}
+  # Example configuration for branding overrides (e.g. via ConfigMap):
+  # configMap:
+  #   name: traccar-branding-configmap
+
+media:
+  enabled: false
+  # Example configuration for persisting media (e.g. via PVC):
+  # persistentVolumeClaim:
+  #   claimName: traccar-media-pvc
+  #
+  # Example configuration for local testing (non-persistent):
+  # emptyDir: {}


### PR DESCRIPTION
## Overview

Following up on the startup permissions fix (#46), this PR adds support for a configurable media volume to handle file/image uploads to `/opt/traccar/media`.

- Adds a new `media` volume configuration block in `values.yaml` (disabled by default) to allow mounting a PVC or other storage volume.
- Automatically default-injects `podSecurityContext.fsGroup` to match the container's `runAsUser` (typically `1000`) if `media.enabled` is true (unless custom fsGroup is defined), ensuring the directory is writeable without manual troubleshooting.
- Includes comments in `values.yaml` documenting PVC and `emptyDir` configuration options.

## Testing Done

Verified in my self-hosted deployment that device images are successfully uploaded and persisted across pod restarts.